### PR TITLE
bug fix

### DIFF
--- a/packages/jecs-utils/src/query-random.luau
+++ b/packages/jecs-utils/src/query-random.luau
@@ -12,6 +12,10 @@ function query_random<T...>(query: jecs.Query<T...>): (jecs.Entity, T...)
 		size = size + #archetype.entities
 	end
 
+	if size == 0 then
+		return nil :: any
+	end
+
 	local random = math.random(1, size)
 	local target_row: number = nil :: any
 	local target_archetype: jecs.Archetype = nil :: any
@@ -27,7 +31,8 @@ function query_random<T...>(query: jecs.Query<T...>): (jecs.Entity, T...)
 		end
 		random -= #entities
 	end
-	if not random or not target_archetype then
+
+	if not target_archetype then
 		return nil :: any
 	end
 


### PR DESCRIPTION
math.random(1, size)

size could possibly be 0, which would cause an error, so I’m adding a check before calling math.random.

Line around 35

Changed from:

if not random or not target_archetype then
    return nil :: any
end


To:

if not target_archetype then
    return nil :: any
end


math.random does not return nil or false when the second parameter is less than the first